### PR TITLE
Remove korean translation commands from github actions

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -49,7 +49,7 @@ jobs:
           DATE="${{ steps.date.outputs.date }}"
           for T in "${TICKERS[@]}"; do
             echo "Running reports for $T on $DATE"
-            python -m gen_reports --ticker "$T" --date "$DATE" --locales EN,KO --translate || echo "gen_reports failed for $T" >&2
+            python -m gen_reports --ticker "$T" --date "$DATE" --locales EN || echo "gen_reports failed for $T" >&2
           done
 
       - name: Commit and push changes


### PR DESCRIPTION
Remove KO locale and translation flag from `generate-reports.yml` to generate reports only in English.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0592c4a-181a-4004-9e30-be33aa66930d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0592c4a-181a-4004-9e30-be33aa66930d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

