### PR TITLE
Summarize financial reports for social media

### DIFF
--- a/report_template.xml
+++ b/report_template.xml
@@ -60,6 +60,21 @@
       <use_analogies>when helpful for clarity</use_analogies>
     </language>
     
+    <!-- SNS summary block to be prepended before headings in simplified reports -->
+    <sns_summary>
+      <enabled>true</enabled>
+      <character_limit>100</character_limit>
+      <rules>
+        <item>Prefix ticker with $ (e.g., $AAPL)</item>
+        <item>One English sentence under the character limit</item>
+        <item>Focus on unique insight/shift/risks from THIS report</item>
+        <item>Avoid generic phrases like “strong AI growth”, “solid earnings”</item>
+        <item>Add line: Confidence: NN%</item>
+        <item>Include compact, relevant hashtags (e.g., #AI #Tech #Stocks #Investing) and #TICKER</item>
+        <item>Output must be clean and X-post ready</item>
+      </rules>
+    </sns_summary>
+
     <length>
       <total_max_words>800</total_max_words>
       <paragraph_max_sentences>3</paragraph_max_sentences>


### PR DESCRIPTION
Add an X(SNS)-ready summary block to the beginning of simplified reports, including ticker, unique insight, confidence, and hashtags, to address TLDR-56.

---
Linear Issue: [TLDR-56](https://linear.app/tl-dr/issue/TLDR-56/글-첫-부분에-핵심-내용-요약)

<a href="https://cursor.com/background-agent?bcId=bc-18bae309-c1af-4ed5-a52f-58bbb7998236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18bae309-c1af-4ed5-a52f-58bbb7998236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

